### PR TITLE
add soft delete and two tests

### DIFF
--- a/test/blockbin.js
+++ b/test/blockbin.js
@@ -3,17 +3,50 @@ var Blockbin = artifacts.require("./Blockbin.sol");
 contract('Blockbin', function(accounts) {
 
     it("should be able to accept named cubes", async function() {
-        let blockbin = await Blockbin.deployed();
+        const blockbin = await Blockbin.deployed();
         await blockbin.dumpCube("oh hai", "myqb");
-        let content = await blockbin.readCube("myqb");
+        const content = await blockbin.readCube("myqb");
         assert.equal("oh hai", web3.toAscii(content));
     });
 
     it("should refuse to override a given cube", async function() {
-        let blockbin = await Blockbin.deployed();
+        const blockbin = await Blockbin.deployed();
         await blockbin.dumpCube("oh hai", "myqb");
         await blockbin.dumpCube("oh hai there", "myqb");
-        let content = await blockbin.readCube("myqb");
+        const content = await blockbin.readCube("myqb");
         assert.equal("oh hai", web3.toAscii(content));
+    });
+
+    it("should return empty bytes when reading emptied cube", async function() {
+        const blockbin = await Blockbin.deployed();
+        await blockbin.dumpCube("oh hai", "myqb");
+
+        // Make sure data stored properly
+        const content = await blockbin.readCube("myqb");
+        assert.equal("oh hai", web3.toAscii(content));
+
+        // Make sure data is removed
+        await blockbin.empty("myqb");
+        const contentAfterEmpty = await blockbin.readCube("myqb");
+        assert.equal("", web3.toAscii(contentAfterEmpty));
+    });
+
+    it("should return empty bytes when reading soft-deleted cube", async function() {
+        const blockbin = await Blockbin.deployed();
+        await blockbin.dumpCube("oh hai", "myqb");
+
+        // Make sure data stored properly
+        const content = await blockbin.readCube("myqb");
+        assert.equal("oh hai", web3.toAscii(content));
+
+        // Make sure data is removed
+        await blockbin.softDelete("myqb");
+        const contentAfterSoftDelete = await blockbin.readCube("myqb");
+        assert.equal("", web3.toAscii(contentAfterSoftDelete));
+
+        // Make sure data is returned
+        await blockbin.softUndelete("myqb");
+        const contentAfterSoftUndelete = await blockbin.readCube("myqb");
+        assert.equal("oh hai", web3.toAscii(contentAfterSoftUndelete));
     });
 });


### PR DESCRIPTION
This PR adds `softDelete()` and `softUndelete()` functionality for cube owners. I don't think we need an admin function for this, since we already have admin power to `empty` any cube. This will be a much more efficient way than `empty()` to remove/hide data if someone wants to delete their cube (albeit insecurely because the history of the blockchain is public and not solely visible through our web interface!).

I added two tests, one for the already-implemented `empty()` and one for `softDelete/softUndelete`.

Mostly, I just wanted to get my feet wet with testing and working in solidity in this codebase. Let's make real progress this weekend! This is a great dev setup thanks to @ArnaudBrousseau  :)